### PR TITLE
Finish saved query support

### DIFF
--- a/AttributeRestrictions/AttributeRestrictions/Tag/DoesNotHaveOneOfTagAttributeRestriction.swift
+++ b/AttributeRestrictions/AttributeRestrictions/Tag/DoesNotHaveOneOfTagAttributeRestriction.swift
@@ -98,15 +98,15 @@ public class DoesNotHaveOneOfTagAttributeRestriction: AnyAttributeRestriction, E
 		return nil
 	}
 
-	public override func stored(
-		for sampleType: Sample.Type,
-		using transaction: Transaction?
-	) throws -> StoredBooleanExpression {
-		throw GenericDisplayableError(
-			title: "Not yet supported",
-			description: "the attribute restriction for 'does not have one of _,_,...,_ tags' cannot yet be saved. As a workaround, use 'and' statements with 'does not have tag _' restrictions."
-		)
-	}
+        public override func stored(
+                for sampleType: Sample.Type,
+                using transaction: Transaction?
+        ) throws -> StoredBooleanExpression {
+                let transaction = transaction ?? injected(Database.self).transaction()
+                let stored = try transaction.new(StoredTagsAttributeRestriction.self)
+                try stored.populate(from: self, for: sampleType)
+                return stored
+        }
 
 	// MARK: - Attributed Functions
 

--- a/AttributeRestrictions/AttributeRestrictions/Tag/HasOneOfTagAttributeRestriction.swift
+++ b/AttributeRestrictions/AttributeRestrictions/Tag/HasOneOfTagAttributeRestriction.swift
@@ -98,15 +98,15 @@ public class HasOneOfTagAttributeRestriction: AnyAttributeRestriction, Equatable
 		return nil
 	}
 
-	public override func stored(
-		for sampleType: Sample.Type,
-		using transaction: Transaction?
-	) throws -> StoredBooleanExpression {
-		throw GenericDisplayableError(
-			title: "Not yet supported",
-			description: "the attribute restriction for 'has one of _,_,...,_ tags' cannot yet be saved. As a workaround, use 'or' statements with 'has tag _' restrictions."
-		)
-	}
+        public override func stored(
+                for sampleType: Sample.Type,
+                using transaction: Transaction?
+        ) throws -> StoredBooleanExpression {
+                let transaction = transaction ?? injected(Database.self).transaction()
+                let stored = try transaction.new(StoredTagsAttributeRestriction.self)
+                try stored.populate(from: self, for: sampleType)
+                return stored
+        }
 
 	// MARK: - Attributed Functions
 

--- a/AttributeRestrictions/AttributeRestrictions/Tag/StoredTagsAttributeRestriction.swift
+++ b/AttributeRestrictions/AttributeRestrictions/Tag/StoredTagsAttributeRestriction.swift
@@ -1,0 +1,63 @@
+import CoreData
+import Foundation
+
+import Attributes
+import BooleanAlgebra
+import Common
+import DependencyInjection
+import Persistence
+import Samples
+
+fileprivate enum TagsRestrictionType: Int16 {
+    case hasOneOf = 0
+    case doesNotHaveOneOf = 1
+}
+
+public final class StoredTagsAttributeRestriction: StoredBooleanExpression, CoreDataObject {
+    private typealias Me = StoredTagsAttributeRestriction
+    public static let entityName = "TagsAttributeRestriction"
+
+    public override func convert() throws -> BooleanExpression {
+        let sampleType: Sample.Type = injected(SampleFactory.self).sampleType(for: sampleTypeId)
+        guard let attribute = sampleType.attributes.first(where: { $0.id == attributeId }) else {
+            throw GenericError("Unable to determine attribute")
+        }
+        let names = tagNames.split(separator: ";").map { String($0) }.filter { !$0.isEmpty }
+        var tags = [Tag]()
+        for name in names {
+            guard let tag = try injected(TagDAO.self).getTag(named: name) else {
+                throw GenericDisplayableError(title: "Tag named '\(name)' does not exist")
+            }
+            tags.append(tag)
+        }
+        switch operation {
+        case TagsRestrictionType.hasOneOf.rawValue:
+            return HasOneOfTagAttributeRestriction(tags: tags, restrictedAttribute: attribute)
+        case TagsRestrictionType.doesNotHaveOneOf.rawValue:
+            return DoesNotHaveOneOfTagAttributeRestriction(tags: tags, restrictedAttribute: attribute)
+        default:
+            throw GenericError("Invalid operation value for StoredTagsAttributeRestriction")
+        }
+    }
+
+    public func populate(from other: AttributeRestriction, for sampleType: Sample.Type) throws {
+        sampleTypeId = injected(SampleFactory.self).sampleTypeId(for: sampleType)
+        attributeId = other.restrictedAttribute.id
+        if let restriction = other as? HasOneOfTagAttributeRestriction {
+            operation = TagsRestrictionType.hasOneOf.rawValue
+            tagNames = restriction.tags.map { $0.name }.joined(separator: ";")
+        } else if let restriction = other as? DoesNotHaveOneOfTagAttributeRestriction {
+            operation = TagsRestrictionType.doesNotHaveOneOf.rawValue
+            tagNames = restriction.tags.map { $0.name }.joined(separator: ";")
+        } else {
+            throw GenericError("Forgot a type of TagsAttributeRestriction")
+        }
+    }
+}
+
+extension StoredTagsAttributeRestriction {
+    @NSManaged private var sampleTypeId: Int16
+    @NSManaged private var attributeId: Int16
+    @NSManaged private var operation: Int16
+    @NSManaged private var tagNames: String
+}

--- a/Introspective/Introspective.xcdatamodeld/Introspective.xcdatamodel/contents
+++ b/Introspective/Introspective.xcdatamodeld/Introspective.xcdatamodel/contents
@@ -207,6 +207,18 @@
         <attribute name="name" attributeType="String"/>
         <relationship name="activityDefinitions" toMany="YES" deletionRule="Nullify" destinationEntity="ActivityDefinition" inverseName="tags" inverseEntity="ActivityDefinition"/>
     </entity>
+    <entity name="SingleTagAttributeRestriction" representedClassName="AttributeRestrictions.StoredSingleTagAttributeRestriction" parentEntity="BooleanExpression" syncable="YES">
+        <attribute name="sampleTypeId" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="attributeId" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="operation" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="tagName" attributeType="String"/>
+    </entity>
+    <entity name="TagsAttributeRestriction" representedClassName="AttributeRestrictions.StoredTagsAttributeRestriction" parentEntity="BooleanExpression" syncable="YES">
+        <attribute name="sampleTypeId" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="attributeId" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="operation" attributeType="Integer 16" usesScalarValueType="YES"/>
+        <attribute name="tagNames" attributeType="String"/>
+    </entity>
     <entity name="TimeOfDayAttributeRestriction" representedClassName="AttributeRestrictions.StoredTimeOfDayAttributeRestriction" parentEntity="BooleanExpression" syncable="YES">
         <attribute name="attributeId" attributeType="Integer 16" usesScalarValueType="YES"/>
         <attribute name="comparison" attributeType="Integer 16" usesScalarValueType="YES"/>
@@ -250,6 +262,8 @@
         <element name="Settings" positionX="-289.8668212890625" positionY="352.4930419921875" width="128" height="254"/>
         <element name="StringOperationAttributeRestriction" positionX="-63" positionY="0" width="128" height="89"/>
         <element name="Tag" positionX="72.3931884765625" positionY="376.8829345703125" width="128" height="30"/>
+        <element name="SingleTagAttributeRestriction" positionX="-54" positionY="9" width="128" height="89"/>
+        <element name="TagsAttributeRestriction" positionX="-54" positionY="9" width="128" height="89"/>
         <element name="TimeOfDayAttributeRestriction" positionX="-27" positionY="36" width="128" height="89"/>
         <element name="WellnessMoodImporter" positionX="-271.3795166015625" positionY="230.5117492675781" width="128" height="30"/>
         <element name="Query" positionX="-81" positionY="-18" width="128" height="74"/>


### PR DESCRIPTION
## Summary
- allow saving tag-based query restrictions
- store multiple-tag restrictions
- update Core Data model with new entities

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68426059c19c8333ad8e69a9a8467623